### PR TITLE
Exclude subdomains from project directory path

### DIFF
--- a/nginx/conf.d/host_resolver
+++ b/nginx/conf.d/host_resolver
@@ -12,7 +12,7 @@ set $_front_controller app.php;
 if ($host ~ "^(.*\.)?(.*)\.(.*)\.php([0-9]*)\..*$") {
     set $_install_dir $2;
     set $_environment $3;
-    set $_php_socket unix:/var/run/php/php$4-fpm.sock;
+    set $_php_socket unix:/var/run/php$4-fpm.sock;
 }
 
 # Symfony >=4


### PR DESCRIPTION
Current host resolver takes everything except environment, PHP version and `ez` (eg. `dev.php73.ez`) as a project directory path. Eg. `bil.frydenbo.dev.php73.ez` will look for the project in this directory: `/var/www/bil.frydenbo`, which prevents using of subdomains for different siteaccesses on the same project.

The solution for this is to create symlinks (eg. `/var/www/bil.frydenbo` -> `/var/www/frydenbo`). Although on this way we keep full  control over all the possible siteaccesses and subdomains, when we have sites with tens of different siteaccesses, the `/var/www` directory can become a real mess with tons of symlinks.

My idea was to use only the "main domain" for matching project directory path, so that `bil.frydenbo.dev.php73.ez` matches `/var/www/frydenbo` and that we can use any number of subdomains and always match the same project directory.

NOTE: I'm not good with regex so there are probably better solutions to this. I've applied the first one that was working fine for me.