### PR TITLE
Update Node.js instructions

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -46,15 +46,16 @@ cd ~
 mkdir n
 ```
 
-You can now update environment variables. In case of `zsh`, add to the
-`~/.zprofile` file:
+You can now update environment variables. If you use `zsh` shell, add to the end
+of the `~/.zprofile` file:
 
 ```shell
 export N_PREFIX=~/"n"
 export PATH=~/"n/bin:$PATH"
 ```
 
-Make sure to preserve any existing modifications of the `PATH` variable.
+Before starting with the next step, restart your terminal app to make sure that
+the path changes are picked up by the shell.
 
 ## 3 Install Node.js through `n`
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -9,7 +9,7 @@ maintain and switch between multiple versions of Node.js.
 First uninstall Node.js, as it will conflict with the versions installed through
 the version manager.
 
-### 1.1 If using MacOS with MacPorts
+### 1.1 If using macOS with MacPorts
 
 Execute on the command line:
 
@@ -17,7 +17,7 @@ Execute on the command line:
 sudo port install n
 ```
 
-### 1.2 If using MacOS with Homebrew
+### 1.2 If using macOS with Homebrew
 
 Execute on the command line:
 
@@ -33,42 +33,72 @@ Execute on the command line:
 sudo apt install n
 ```
 
-## 2 Install Node.js through `n`
+## 2 Configure
+
+To avoid requiring `sudo` for `n` and `npm` global installs, configure
+environment variable `N_PREFIX`, which will point to the place where `n` will
+store Node.js binaries. With this you will also need to update the `PATH`
+environment variable, so that the system can find the active binaries. Execute
+on the command line:
+
+```console
+cd ~
+mkdir n
+```
+
+You can now update environment variables. In case of `zsh`, add to the
+`~/.zprofile` file:
+
+```shell
+export N_PREFIX=~/"n"
+export PATH=~/"n/bin:$PATH"
+```
+
+Make sure to preserve any existing modifications of the `PATH` variable.
+
+## 3 Install Node.js through `n`
 
 You can now use `n` to install Node.js, for example latest and LTS versions:
 
 ```console
-sudo n lts
-sudo n latest
+n latest
+n lts
 ```
 
 To install exact version of Node.js, for example `10.16.0`, execute on the
 command line:
 
 ```console
-sudo n 10.16.0
+n 10.16.0
+```
+
+You can also install the latest release of the specific major version, for
+example `12`, with:
+
+```console
+n 12
 ```
 
 Note that each version on Node.js installed through `n` will come with its own
 version of `npm`.
 
-## 3 Install a package with `npm`
+## 4 Install a package with `npm`
 
 To install a package globally, for example `yarn`, execute on the command line:
 
 ```console
-sudo npm install -g yarn
+npm install -g yarn
 ```
 
 Packages installed globally with `npm` will be installed independently of the
 version of Node.js that is currently active.
 
-## 4 Switch between different versions of Node.js
+## 5 Switch between different versions of Node.js
 
 To switch between different versions of Node.js, execute on the command line:
 
 ```console
-sudo n
+n
 ```
 
 Then select between available versions of Node.js.


### PR DESCRIPTION
It seems that using sudo for `npm install` is not a very good idea: https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-5711d2726aa3
Also, if `~/.confifg` was not previously created through a different process, using `sudo npm install` for the first time will create `~/.confifg`  with `root` ownership, which can cause problems later on.

This updates instructions for `n` that enable using `npm` without sudo.

Testing: if already installed using previous instructions, first uninstall `yarn` (`sudo npm uninstall -g yarn`), remove all Node.js versions installed through `n` (`sudo n` and then delete installed versions with `d`), then go through step 2 and verify that you can now use `n` and `npm` without sudo.