### PR TITLE
Define default server for NGINX

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -77,10 +77,16 @@ cd /opt/local/etc/nginx/sites-enabled
 sudo ln -s ../sites-available/* ./
 ```
 
-Paths in the copied configuration files are already correct for MacOS using
-MacPorts, so you are done with this step.
+Paths in the copied configuration files are already correct for macOS using
+MacPorts, so no adjustments are needed.
 
-### 2.2 If using MacOS with Homebrew
+To finish this step set permissions on the log directory:
+
+```console
+sudo chown -R brale:staff /opt/local/var/log/nginx
+```
+
+### 2.2 If using macOS with Homebrew
 
 Copy the configuration files to the configuration directory:
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,13 @@ http {
         return 503 '<h1>No server is configured for the requested host</h1>';
     }
 
+    # the following block will automatically redirect requests from http to https
+    #server {
+    #    listen 127.0.0.1:80;
+    #    server_name _;
+    #    return 301 https://$http_host$request_uri;
+    #}
+
     server {
         listen 127.0.0.1:8080 ssl;
         server_name _;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,6 +20,13 @@ http {
     ssl_certificate_key server.key;
 
     server {
+        listen 127.0.0.1:80 default_server;
+        listen 127.0.0.1:443 ssl default_server;
+        default_type text/html;
+        return 503 '<h1>No server is configured for the requested host</h1>';
+    }
+
+    server {
         listen 127.0.0.1:8080 ssl;
         server_name _;
 


### PR DESCRIPTION
In case no default server is explicitly defined, NGINX will use the first available server as the default one. In some cases this can result in partially working configuration that is not immediately visible. This defines explicit default server that will give a descriptive message to the user.

Additionally this documents necessary permission NGINX on log directories on macOS with Macports and adds a commented out block for automatic redirect from HTTP to HTTPS.