### PR TITLE
MacPorts: PHP 8.0 and 8.1, configure MySQL custom socket, character set and collation

### DIFF
--- a/curl/README.md
+++ b/curl/README.md
@@ -47,7 +47,8 @@ the NGINX step, check that everything is correct with:
 curl --head https://phpinfo.php74
 ```
 
-You should receive an output like below:
+Make sure that scheme part of the URL from the command above is `https`. You
+should receive an output like below:
 
 ```console
 HTTP/1.1 200 OK

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -164,9 +164,16 @@ basedir="/opt/local"
 bind-address=127.0.0.1
 binlog_expire_logs_seconds=86400
 socket=/var/run/mysqld/mysqld.sock
+collation-server=utf8mb4_unicode_520_ci
+character-set-server=utf8mb4
+init-connect='SET NAMES utf8mb4'
 
 [client]
 socket=/var/run/mysqld/mysqld.sock
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
 ```
 
 Configuring path to the socket file explicitly will be useful if you need to

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -163,6 +163,20 @@ default MacPorts settings and add the following configuration:
 basedir="/opt/local"
 bind-address=127.0.0.1
 binlog_expire_logs_seconds=86400
+socket=/var/run/mysqld/mysqld.sock
+
+[client]
+socket=/var/run/mysqld/mysqld.sock
+```
+
+Configuring path to the socket file explicitly will be useful if you need to
+use multiple versions of MySQL, as you will not need to update PHP configuration
+when changing between them. This will also require creating the directory where
+the socket file will be placed and setting up the correct permissions on it:
+
+```console
+sudo mkdir /var/run/mysqld
+sudo chown _mysql:_mysql /var/run/mysqld
 ```
 
 Now reload the server with:

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -2,13 +2,13 @@
 
 ## 1 Install
 
-## 1.1 Install on MacOS using MacPorts
+## 1.1 Install on macOS using MacPorts
 
 ```console
 sudo port install nginx
 ```
 
-## 1.2 Install on MacOS using Homebrew
+## 1.2 Install on macOS using Homebrew
 
 ```console
 brew install nginx
@@ -59,7 +59,7 @@ git clone git@github.com:netgen/local-development-setup.git
 They you will also need to find the location of configuration files and logs,
 which depends on the OS and package manager.
 
-### 2.1 If using MacOS with MacPorts
+### 2.1 If using macOS with MacPorts
 
 Copy the configuration files to the configuration directory:
 
@@ -153,7 +153,7 @@ cd /etc/nginx/sites-enabled
 sudo ln -s ../sites-available/* ./
 ```
 
-Ubuntu uses different directories for enabled vhosts and log files so we need to update these:
+Ubuntu uses different directories for enabled vhosts and log files, so we need to update these:
 
 ```console
 cd /etc/nginx
@@ -173,7 +173,7 @@ sudo chmod -R u+X /var/log/nginx
 SSL certificates created in one of the previous steps need to be linked to the
 NGINX configuration directory.
 
-### 3.1 If using MacOS with MacPorts
+### 3.1 If using macOS with MacPorts
 
 Execute on the command line:
 
@@ -183,7 +183,7 @@ sudo ln -s ~/ssl/server.crt
 sudo ln -s ~/ssl/server.key
 ```
 
-### 3.2 If using MacOS with Homebrew
+### 3.2 If using macOS with Homebrew
 
 Execute on the command line:
 
@@ -205,7 +205,7 @@ sudo ln -s ~/ssl/server.key
 
 ## 4 Start the server
 
-### 4.1 If using MacOS with MacPorts
+### 4.1 If using macOS with MacPorts
 
 ```console
 sudo port load nginx
@@ -213,7 +213,7 @@ sudo port load nginx
 
 This will also start the server automatically after a reboot.
 
-### 4.2 If using MacOS with Homebrew
+### 4.2 If using macOS with Homebrew
 
 ```console
 sudo brew services start nginx
@@ -238,17 +238,17 @@ To check if Nginx service is enabled to start after reboot, try:
 sudo systemctl is-enabled nginx
 ```
 
-To enable it to automatically start after reboot:
+To enable it to automatically start after a reboot:
 
 ```console
 sudo systemctl enable nginx
 ```
 
-## 5 Install websites
+## 5 Installation of websites
 
 Now you can install websites provided in `websites` directory in the root of the
 repository. Websites will be located in `/var/www` directory. While this folder
-already exists on Ubuntu, on MacOS you need to generate it first:
+already exists on Ubuntu, on macOS you need to generate it first:
 
 ```console
 sudo mkdir /var/www

--- a/php/README.md
+++ b/php/README.md
@@ -3,7 +3,7 @@
 Here you will install multiple versions of PHP and configure them to run in FPM
 mode.
 
-If using MacOS and Homebrew, out of the box it provides current PHP version
+If using macOS and Homebrew, out of the box it provides current PHP version
 in a package named `php` (version 7.4 at the time of writing), and other
 officially supported PHP versions in packages namespaced with version number,
 for example `php@7.3`. Officially unsupported PHP packages are not available in
@@ -12,28 +12,30 @@ provided in some 3rd party *taps*, and it's possible to install them from there.
 
 ## 1 Install
 
-### 1.1 If using MacOS with MacPorts
+### 1.1 If using macOS with MacPorts
 
 Execute on the command line:
 
 ```console
-sudo port install php74-fpm php74-mysql php74-imagick php74-gd php74-curl php74-opcache php74-mbstring php74-xsl php74-intl php74-sqlite php74-zip php74-openssl php74-iconv
-sudo port install php73-fpm php73-mysql php73-imagick php73-gd php73-curl php73-opcache php73-mbstring php73-xsl php73-intl php73-sqlite php73-zip php73-openssl php73-iconv
-sudo port install php72-fpm php72-mysql php72-imagick php72-gd php72-curl php72-opcache php72-mbstring php72-xsl php72-intl php72-sqlite php72-zip php72-openssl php72-iconv
-sudo port install php71-fpm php71-mysql php71-imagick php71-gd php71-curl php71-opcache php71-mbstring php71-xsl php71-intl php71-sqlite php71-zip php71-openssl php71-iconv
-sudo port install php70-fpm php70-mysql php70-imagick php70-gd php70-curl php70-opcache php70-mbstring php70-xsl php70-intl php70-sqlite php70-zip php70-openssl php70-iconv
-sudo port install php56-fpm php56-mysql php56-imagick php56-gd php56-curl php56-opcache php56-mbstring php56-xsl php56-intl php56-sqlite php56-zip php56-openssl php56-iconv php56-memcached
+sudo port install php81-fpm php81-mysql php81-imagick php81-gd php81-curl php81-opcache php81-mbstring php81-xsl php81-intl php81-sqlite php81-zip php81-openssl php81-iconv php81-sockets php81-exif php81-memcached
+sudo port install php80-fpm php80-mysql php80-imagick php80-gd php80-curl php80-opcache php80-mbstring php80-xsl php80-intl php80-sqlite php80-zip php80-openssl php80-iconv php80-sockets php80-exif php80-memcached
+sudo port install php74-fpm php74-mysql php74-imagick php74-gd php74-curl php74-opcache php74-mbstring php74-xsl php74-intl php74-sqlite php74-zip php74-openssl php74-iconv php74-sockets php74-exif php74-memcached
+sudo port install php73-fpm php73-mysql php73-imagick php73-gd php73-curl php73-opcache php73-mbstring php73-xsl php73-intl php73-sqlite php73-zip php73-openssl php73-iconv php73-sockets php73-exif php73-memcached
+sudo port install php72-fpm php72-mysql php72-imagick php72-gd php72-curl php72-opcache php72-mbstring php72-xsl php72-intl php72-sqlite php72-zip php72-openssl php72-iconv php72-sockets php72-exif php72-memcached
+sudo port install php71-fpm php71-mysql php71-imagick php71-gd php71-curl php71-opcache php71-mbstring php71-xsl php71-intl php71-sqlite php71-zip php71-openssl php71-iconv php71-sockets php71-exif php71-memcached
+sudo port install php70-fpm php70-mysql php70-imagick php70-gd php70-curl php70-opcache php70-mbstring php70-xsl php70-intl php70-sqlite php70-zip php70-openssl php70-iconv php70-sockets php70-exif php70-memcached
+sudo port install php56-fpm php56-mysql php56-imagick php56-gd php56-curl php56-opcache php56-mbstring php56-xsl php56-intl php56-sqlite php56-zip php56-openssl php56-iconv php56-sockets php56-exif php56-memcached
 ```
 
 Select desired default PHP version:
 
 ```console
-sudo port select php php73
+sudo port select php php74
 ```
 
 This PHP version will be available from the command line as `php`.
 
-### 1.2 If using MacOS with Homebrew
+### 1.2 If using macOS with Homebrew
 
 Install PHP 7.4, 7.3 and 7.2 using Homebrew from the official *tap*:
 
@@ -152,6 +154,8 @@ Update these pool definition files as described above.
 First create PHP-FPM configuration files by copying the default ones:
 
 ```console
+sudo cp /opt/local/etc/php81/php-fpm.conf.default /opt/local/etc/php81/php-fpm.conf
+sudo cp /opt/local/etc/php80/php-fpm.conf.default /opt/local/etc/php80/php-fpm.conf
 sudo cp /opt/local/etc/php74/php-fpm.conf.default /opt/local/etc/php74/php-fpm.conf
 sudo cp /opt/local/etc/php73/php-fpm.conf.default /opt/local/etc/php73/php-fpm.conf
 sudo cp /opt/local/etc/php72/php-fpm.conf.default /opt/local/etc/php72/php-fpm.conf
@@ -165,6 +169,8 @@ You don't need to change the default configuration values.
 Next, create PHP-FPM pool definitions by copying the default ones:
 
 ```console
+sudo cp /opt/local/etc/php81/php-fpm.d/www.conf.default /opt/local/etc/php81/php-fpm.d/www.conf
+sudo cp /opt/local/etc/php80/php-fpm.d/www.conf.default /opt/local/etc/php80/php-fpm.d/www.conf
 sudo cp /opt/local/etc/php74/php-fpm.d/www.conf.default /opt/local/etc/php74/php-fpm.d/www.conf
 sudo cp /opt/local/etc/php73/php-fpm.d/www.conf.default /opt/local/etc/php73/php-fpm.d/www.conf
 sudo cp /opt/local/etc/php72/php-fpm.d/www.conf.default /opt/local/etc/php72/php-fpm.d/www.conf
@@ -231,6 +237,8 @@ Update these configuration files as described above.
 First create PHP configuration files by copying the default ones:
 
 ```console
+sudo cp /opt/local/etc/php81/php.ini-development /opt/local/etc/php81/php.ini
+sudo cp /opt/local/etc/php80/php.ini-development /opt/local/etc/php80/php.ini
 sudo cp /opt/local/etc/php74/php.ini-development /opt/local/etc/php74/php.ini
 sudo cp /opt/local/etc/php73/php.ini-development /opt/local/etc/php73/php.ini
 sudo cp /opt/local/etc/php72/php.ini-development /opt/local/etc/php72/php.ini
@@ -242,8 +250,8 @@ sudo cp /opt/local/etc/php56/php.ini-development /opt/local/etc/php56/php.ini
 Update the created configuration files as described above and additionally with:
 
 ```ini
-pdo_mysql.default_socket=/opt/local/var/run/mysql8/mysqld.sock
-mysqli.default_socket=/opt/local/var/run/mysql8/mysqld.sock
+pdo_mysql.default_socket=/var/run/mysqld/mysqld.sock
+mysqli.default_socket=/var/run/mysqld/mysqld.sock
 ```
 
 This will enable using `localhost` as the database host from your application.
@@ -291,6 +299,8 @@ minor version numbers.
 Symlink each PHP binary to an easily accessible alias:
 
 ```console
+ln -s /opt/local/bin/php81 ~/bin/php8.1
+ln -s /opt/local/bin/php80 ~/bin/php8.0
 ln -s /opt/local/bin/php74 ~/bin/php7.4
 ln -s /opt/local/bin/php73 ~/bin/php7.3
 ln -s /opt/local/bin/php72 ~/bin/php7.2
@@ -349,6 +359,8 @@ sudo brew services stop phpxx-fpm
 ### 5.2 Start PHP-FPM services if installed using MacPorts
 
 ```console
+sudo port load php81-fpm
+sudo port load php80-fpm
 sudo port load php74-fpm
 sudo port load php73-fpm
 sudo port load php72-fpm

--- a/redis/README.md
+++ b/redis/README.md
@@ -6,7 +6,7 @@ implementation.
 
 ## 1 Install
 
-### 1.1 If using MacOS with MacPorts
+### 1.1 If using macOS with MacPorts
 
 Execute on the command line:
 
@@ -14,7 +14,7 @@ Execute on the command line:
 sudo port install redis
 ```
 
-### 1.2 If using MacOS with Homebrew
+### 1.2 If using macOS with Homebrew
 
 Execute on the command line:
 
@@ -53,7 +53,7 @@ To stop the server and prevent it from running after a reboot, execute:
 sudo port unload redis
 ```
 
-#### 2.1.2 If using MacOS with Homebrew
+#### 2.1.2 If using macOS with Homebrew
 
 Execute on the command line:
 

--- a/websites/home/index.php
+++ b/websites/home/index.php
@@ -65,6 +65,8 @@ header("Cache-Control: no-cache, must-revalidate");
     <h2>services</h2>
     <hr>
     <ol>
+        <li>PHP 8.1 <a href="https://phpinfo.php81">info</a> | <a href="https://home.php81/status?full&html">status</a></li>
+        <li>PHP 8.0 <a href="https://phpinfo.php80">info</a> | <a href="https://home.php80/status?full&html">status</a></li>
         <li>PHP 7.4 <a href="https://phpinfo.php74">info</a> | <a href="https://home.php74/status?full&html">status</a></li>
         <li>PHP 7.3 <a href="https://phpinfo.php73">info</a> | <a href="https://home.php73/status?full&html">status</a></li>
         <li>PHP 7.2 <a href="https://phpinfo.php72">info</a> | <a href="https://home.php72/status?full&html">status</a></li>


### PR DESCRIPTION
This updates MacPorts instructions for:

- PHP 8.0 and 8.1
- MySQL custom socket configuration
- MySQL character set and collation configuration (https://github.com/netgen/local-development-setup/commit/66a4be6dc21ad5a352eccdceef55ddcc2f78471c)

Additionally I did some minor language fixes.