### PR TITLE
NGSTACK-575 make composer and php files consistent

### DIFF
--- a/docs/source/macos/composer.rst
+++ b/docs/source/macos/composer.rst
@@ -49,22 +49,22 @@ Copy the following into the alias file:
 
 ::
 
-    alias composer561="/usr/bin/php5.6 /usr/local/bin/composer1"
-    alias composer562="/usr/bin/php5.6 /usr/local/bin/composer2"
-    alias composer701="/usr/bin/php7.0 /usr/local/bin/composer1"
-    alias composer702="/usr/bin/php7.0 /usr/local/bin/composer2"
-    alias composer711="/usr/bin/php7.1 /usr/local/bin/composer1"
-    alias composer712="/usr/bin/php7.1 /usr/local/bin/composer2"
-    alias composer721="/usr/bin/php7.2 /usr/local/bin/composer1"
-    alias composer722="/usr/bin/php7.2 /usr/local/bin/composer2"
-    alias composer731="/usr/bin/php7.3 /usr/local/bin/composer1"
-    alias composer732="/usr/bin/php7.3 /usr/local/bin/composer2"
-    alias composer741="/usr/bin/php7.4 /usr/local/bin/composer1"
-    alias composer742="/usr/bin/php7.4 /usr/local/bin/composer2"
-    alias composer801="/usr/bin/php8.0 /usr/local/bin/composer1"
-    alias composer802="/usr/bin/php8.0 /usr/local/bin/composer2"
-    alias composer811="/usr/bin/php8.1 /usr/local/bin/composer1"
-    alias composer812="/usr/bin/php8.1 /usr/local/bin/composer2"
+    alias composer561="/usr/local/bin/php56 /usr/local/bin/composer"
+    alias composer562="/usr/local/bin/php56 /usr/local/bin/composer2"
+    alias composer701="/usr/local/bin/php70 /usr/local/bin/composer"
+    alias composer702="/usr/local/bin/php70 /usr/local/bin/composer2"
+    alias composer711="/usr/local/bin/php71 /usr/local/bin/composer"
+    alias composer712="/usr/local/bin/php71 /usr/local/bin/composer2"
+    alias composer721="/usr/local/bin/php72 /usr/local/bin/composer"
+    alias composer722="/usr/local/bin/php72 /usr/local/bin/composer2"
+    alias composer731="/usr/local/bin/php73 /usr/local/bin/composer"
+    alias composer732="/usr/local/bin/php73 /usr/local/bin/composer2"
+    alias composer741="/usr/local/bin/php74 /usr/local/bin/composer"
+    alias composer742="/usr/local/bin/php74 /usr/local/bin/composer2"
+    alias composer801="/usr/local/bin/php80 /usr/local/bin/composer"
+    alias composer802="/usr/local/bin/php80 /usr/local/bin/composer2"
+    alias composer811="/usr/local/bin/php81 /usr/local/bin/composer"
+    alias composer812="/usr/local/bin/php81 /usr/local/bin/composer2"
 
 3 Manual upgrade/downgrade
 --------------------------

--- a/docs/source/macos/php.rst
+++ b/docs/source/macos/php.rst
@@ -230,12 +230,12 @@ Symlink each PHP binary to an easily accessible alias:
 
 .. code:: console
 
-   ln -s /usr/local/Cellar/php@7.4/7.4.xx/bin/php ~/bin/php7.4
-   ln -s /usr/local/Cellar/php@7.3/7.3.xx/bin/php ~/bin/php7.3
-   ln -s /usr/local/Cellar/php@7.2/7.2.xx/bin/php ~/bin/php7.2
-   ln -s /usr/local/Cellar/php@7.1/7.1.xx/bin/php ~/bin/php7.1
-   ln -s /usr/local/Cellar/php@7.0/7.0.xx/bin/php ~/bin/php7.0
-   ln -s /usr/local/Cellar/php@5.6/5.6.xx/bin/php ~/bin/php5.6
+   sudo ln -s /usr/local/Cellar/php@7.4/7.4.xx/bin/php /usr/local/bin/php74
+   sudo ln -s /usr/local/Cellar/php@7.3/7.3.xx/bin/php /usr/local/bin/php73
+   sudo ln -s /usr/local/Cellar/php@7.2/7.2.xx/bin/php /usr/local/bin/php72
+   sudo ln -s /usr/local/Cellar/php@7.1/7.1.xx/bin/php /usr/local/bin/php71
+   sudo ln -s /usr/local/Cellar/php@7.0/7.0.xx/bin/php /usr/local/bin/php70
+   sudo ln -s /usr/local/Cellar/php@5.6/5.6.xx/bin/php /usr/local/bin/php56
 
 Make sure you use correct paths to the PHP binary. This path will change
 when upgrading a PHP version, so you will need to maintain your symlinks
@@ -253,14 +253,14 @@ Symlink each PHP binary to an easily accessible alias:
 
 .. code:: console
 
-   ln -s /opt/local/bin/php81 ~/bin/php8.1
-   ln -s /opt/local/bin/php80 ~/bin/php8.0
-   ln -s /opt/local/bin/php74 ~/bin/php7.4
-   ln -s /opt/local/bin/php73 ~/bin/php7.3
-   ln -s /opt/local/bin/php72 ~/bin/php7.2
-   ln -s /opt/local/bin/php71 ~/bin/php7.1
-   ln -s /opt/local/bin/php70 ~/bin/php7.0
-   ln -s /opt/local/bin/php56 ~/bin/php5.6
+   sudo ln -s /opt/local/bin/php81 /usr/local/bin/php81
+   sudo ln -s /opt/local/bin/php80 /usr/local/bin/php80
+   sudo ln -s /opt/local/bin/php74 /usr/local/bin/php74
+   sudo ln -s /opt/local/bin/php73 /usr/local/bin/php73
+   sudo ln -s /opt/local/bin/php72 /usr/local/bin/php72
+   sudo ln -s /opt/local/bin/php71 /usr/local/bin/php71
+   sudo ln -s /opt/local/bin/php70 /usr/local/bin/php70
+   sudo ln -s /opt/local/bin/php56 /usr/local/bin/php56
 
 4.4 Test
 ~~~~~~~~

--- a/docs/source/ubuntu/composer.rst
+++ b/docs/source/ubuntu/composer.rst
@@ -50,21 +50,21 @@ Copy the following into the alias file:
 
 ::
 
-    alias composer561="/usr/bin/php5.6 /usr/local/bin/composer1"
+    alias composer561="/usr/bin/php5.6 /usr/local/bin/composer"
     alias composer562="/usr/bin/php5.6 /usr/local/bin/composer2"
-    alias composer701="/usr/bin/php7.0 /usr/local/bin/composer1"
+    alias composer701="/usr/bin/php7.0 /usr/local/bin/composer"
     alias composer702="/usr/bin/php7.0 /usr/local/bin/composer2"
-    alias composer711="/usr/bin/php7.1 /usr/local/bin/composer1"
+    alias composer711="/usr/bin/php7.1 /usr/local/bin/composer"
     alias composer712="/usr/bin/php7.1 /usr/local/bin/composer2"
-    alias composer721="/usr/bin/php7.2 /usr/local/bin/composer1"
+    alias composer721="/usr/bin/php7.2 /usr/local/bin/composer"
     alias composer722="/usr/bin/php7.2 /usr/local/bin/composer2"
-    alias composer731="/usr/bin/php7.3 /usr/local/bin/composer1"
+    alias composer731="/usr/bin/php7.3 /usr/local/bin/composer"
     alias composer732="/usr/bin/php7.3 /usr/local/bin/composer2"
-    alias composer741="/usr/bin/php7.4 /usr/local/bin/composer1"
+    alias composer741="/usr/bin/php7.4 /usr/local/bin/composer"
     alias composer742="/usr/bin/php7.4 /usr/local/bin/composer2"
-    alias composer801="/usr/bin/php8.0 /usr/local/bin/composer1"
+    alias composer801="/usr/bin/php8.0 /usr/local/bin/composer"
     alias composer802="/usr/bin/php8.0 /usr/local/bin/composer2"
-    alias composer811="/usr/bin/php8.1 /usr/local/bin/composer1"
+    alias composer811="/usr/bin/php8.1 /usr/local/bin/composer"
     alias composer812="/usr/bin/php8.1 /usr/local/bin/composer2"
 
 3 Manual upgrade/downgrade


### PR DESCRIPTION
PHP and composer setup instructions were inconsistent: php path set to one thing in php instructions, and then used another in the composer instructions.

Also, in composer instruction file, `composer.phar` version 1 moved to `composer`, but then used `composer1` when setting `phpxyz` aliases.

This PR fixes these inconsistencies.