### PR TITLE
Add mysql_native_password setting for mysql 8.4

### DIFF
--- a/docs/source/macos/mysql.rst
+++ b/docs/source/macos/mysql.rst
@@ -130,6 +130,7 @@ configuration:
    collation-server=utf8mb4_unicode_520_ci
    character-set-server=utf8mb4
    init-connect='SET NAMES utf8mb4'
+   mysql_native_password=ON
 
    [client]
    socket=/opt/local/var/run/mysql/mysqld.sock


### PR DESCRIPTION
In MySQL 8.4, `caching_sha2_password` is the default authentication plugin rather than `mysql_native_password` (deprecated).

On the other hand, `caching_sha2_password` is a plugin that is not recognized by the older PHP releases (fully supported as of PHP 7.4.4), so for now we default to manually setting the deprecated plugin in local dev setup.