### PR TITLE
NGSTACK-1022 lds docs update

### DIFF
--- a/docs/source/macos/composer.rst
+++ b/docs/source/macos/composer.rst
@@ -17,7 +17,7 @@ Use the above instructions to download the composer to your machine.
 Don't forget adding composer into a directory on PATH
 .. code:: console
 
-   sudo mv composer.phar /opt/local/bin/composer
+   sudo mv composer.phar /usr/local/bin/composer
 
 That is it!
 
@@ -34,9 +34,9 @@ Copy the following into the alias file:
 
 ::
 
-    alias composer74="/opt/local/bin/php74 /opt/local/bin/composer"
-    alias composer80="/opt/local/bin/php80 /opt/local/bin/composer"
-    alias composer81="/opt/local/bin/php81 /opt/local/bin/composer"
-    alias composer82="/opt/local/bin/php81 /opt/local/bin/composer"
-    alias composer83="/opt/local/bin/php81 /opt/local/bin/composer"
-    alias composer84="/opt/local/bin/php81 /opt/local/bin/composer"
+    alias composer74="/usr/local/bin/php74 /usr/local/bin/composer"
+    alias composer80="/usr/local/bin/php80 /usr/local/bin/composer"
+    alias composer81="/usr/local/bin/php81 /usr/local/bin/composer"
+    alias composer82="/usr/local/bin/php81 /usr/local/bin/composer"
+    alias composer83="/usr/local/bin/php81 /usr/local/bin/composer"
+    alias composer84="/usr/local/bin/php81 /usr/local/bin/composer"

--- a/docs/source/macos/composer.rst
+++ b/docs/source/macos/composer.rst
@@ -14,29 +14,14 @@ find detailed instructions on https://getcomposer.org/download/.
 
 Use the above instructions to download the composer to your machine.
 
-Next step is making sure version 2 is available globally under
-``composer2`` command:
-
+Don't forget adding composer into a directory on PATH
 .. code:: console
 
-   cp composer.phar /usr/local/bin/composer2
-
-We also need version 1, as not all projects support version 2 yet:
-
-.. code:: console
-
-   php composer.phar self-update --1
-
-And now just make sure ``composer`` command is available globally:
-
-.. code:: console
-
-   mv composer.phar /usr/local/bin/composer
+   sudo mv composer.phar /opt/local/bin/composer
 
 That is it!
 
-Now you should be able to run ``composer install`` for projects using
-composer1 and ``composer2 install`` for projects using composer2
+Now you should be able to run ``composer install`` in projects.
 
 2 Aliases
 ---------
@@ -49,37 +34,9 @@ Copy the following into the alias file:
 
 ::
 
-    alias composer561="/usr/local/bin/php56 /usr/local/bin/composer"
-    alias composer562="/usr/local/bin/php56 /usr/local/bin/composer2"
-    alias composer701="/usr/local/bin/php70 /usr/local/bin/composer"
-    alias composer702="/usr/local/bin/php70 /usr/local/bin/composer2"
-    alias composer711="/usr/local/bin/php71 /usr/local/bin/composer"
-    alias composer712="/usr/local/bin/php71 /usr/local/bin/composer2"
-    alias composer721="/usr/local/bin/php72 /usr/local/bin/composer"
-    alias composer722="/usr/local/bin/php72 /usr/local/bin/composer2"
-    alias composer731="/usr/local/bin/php73 /usr/local/bin/composer"
-    alias composer732="/usr/local/bin/php73 /usr/local/bin/composer2"
-    alias composer741="/usr/local/bin/php74 /usr/local/bin/composer"
-    alias composer742="/usr/local/bin/php74 /usr/local/bin/composer2"
-    alias composer801="/usr/local/bin/php80 /usr/local/bin/composer"
-    alias composer802="/usr/local/bin/php80 /usr/local/bin/composer2"
-    alias composer811="/usr/local/bin/php81 /usr/local/bin/composer"
-    alias composer812="/usr/local/bin/php81 /usr/local/bin/composer2"
-
-3 Manual upgrade/downgrade
---------------------------
-
-If you do not wish to use aliases, but manually upgrade/downgrade
-composer, you can switch with the following commands:
-
-Switch to version 1:
-
-.. code:: console
-
-   composer self-update --1
-
-Switch to version 2:
-
-.. code:: console
-
-   composer self-update --2
+    alias composer74="/opt/local/bin/php74 /opt/local/bin/composer"
+    alias composer80="/opt/local/bin/php80 /opt/local/bin/composer"
+    alias composer81="/opt/local/bin/php81 /opt/local/bin/composer"
+    alias composer82="/opt/local/bin/php81 /opt/local/bin/composer"
+    alias composer83="/opt/local/bin/php81 /opt/local/bin/composer"
+    alias composer84="/opt/local/bin/php81 /opt/local/bin/composer"

--- a/docs/source/macos/curl.rst
+++ b/docs/source/macos/curl.rst
@@ -35,8 +35,12 @@ You should receive an output similar to:
    )
 
 The value of ``default_cert_file`` key from above is the location of the
-bundle where the RCA certificates are stored. Add your own RCA
-certificate to the bundle with:
+bundle where the RCA certificates are stored.
+
+**Note**: The ``default_cert_file path`` on your system may differ from the example above.
+Make sure to use the ``default_cert_file`` value from your output in the command below.
+
+Add your own RCA certificate to the bundle with:
 
 .. code:: console
 

--- a/docs/source/macos/dnsmasq.rst
+++ b/docs/source/macos/dnsmasq.rst
@@ -94,17 +94,7 @@ This will also start the server automatically after a reboot.
 
 This will also start the service automatically after a reboot.
 
-4 Update network connections
-----------------------------
-
-Open Network configuration in System Preferences, click Advanced on your
-network connection, select DNS tab and add ``127.0.0.1`` as a DNS
-server.
-
-Repeat this with all network connections you are using to connect to the
-Internet, excluding VPN connections.
-
-5 Test
+4 Test
 ------
 
 Test resolving by pinging a bogus domain on your custom top-level

--- a/docs/source/macos/haproxy.rst
+++ b/docs/source/macos/haproxy.rst
@@ -83,6 +83,8 @@ Create configuration file ``/opt/local/etc/haproxy/haproxy.cfg`` with the follow
 
 Make sure to adapt the paths to certificate chain file on your system.
 
+Also, ensure the file ends with a trailing newline (LF), otherwise HAProxy may fail to start.
+
 Create port map file ``/opt/local/etc/haproxy/node_domains_ports.map`` with the following content:
 
 .. code:: console

--- a/docs/source/macos/nginx.rst
+++ b/docs/source/macos/nginx.rst
@@ -63,7 +63,7 @@ configurations:
 Paths in the copied configuration files are already correct for macOS
 using MacPorts, so no adjustments are needed.
 
-To finish this step set permissions on the log directory:
+To finish this step set permissions on the log directory (don't forget to change the user):
 
 .. code:: console
 
@@ -176,7 +176,7 @@ to generate it first:
 
    sudo mkdir /var/www
 
-Then we need to set the permissions on this directory:
+Then we need to set the permissions on this directory  (don't forget to change the user):
 
 .. code:: console
 
@@ -205,7 +205,7 @@ used to serve the website.
    Before configuring HAProxy (in the next section) you will be able to
    access the websites only through ports ``8080`` (HTTP) and ``8443``
    (HTTPS). After configuring HAProxy, you will be able to access them
-   though default ports ``80`` and ``443``.
+   through default ports ``80`` and ``443``.
 
 Testing your website on a different device
 ------------------------------------------
@@ -214,14 +214,14 @@ This setup works with multiple custom local domains, which is not
 trivial to directly expose on a local network, since it would need to
 involve a DNS server.
 
-However, is possible to expose a specific website on your local IP,
+However, it is possible to expose a specific website on your local IP,
 which you can then use to open the website on a different device
 connected to your local network, for example smartphone or a tablet. To
 do that, uncomment the configuration block found in:
 
 ::
 
-   /usr/local/etc/nginx/sites-enabled/local_network_proxy
+   /opt/local/etc/nginx/sites-enabled/local_network_proxy
 
 Then adjust the IP and local website address as needed.
 

--- a/docs/source/macos/nodejs.rst
+++ b/docs/source/macos/nodejs.rst
@@ -13,6 +13,9 @@ since the `Netgen Media Site` Makefile is configured to be used with that one.
 First uninstall Node.js, as it will conflict with the versions installed
 through the version manager.
 
+1.1 Install via github
+^^^^^^^^^^^^^^^^^^^^^^
+
 The installation should be fairly straightforward if you follow the instructions at
 `Github <https://github.com/nvm-sh/nvm#install--update-script>`_:
 
@@ -20,7 +23,7 @@ The installation should be fairly straightforward if you follow the instructions
 
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
-Make sure to check the correct version, please do not just copy the link above as
+Make sure to **check the correct version**, please do not just copy the link above as
 it could be an old/deprecated version.
 
 This will install the ``nvm`` to ``~/.nvm`` folder, and attempt to modify your profile file
@@ -32,10 +35,9 @@ If you have any other profile file, please add the following to the file your se
     export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
 
-Alternatively, you can install ``nvm`` through one of the package managers:
-
-* Brew: https://formulae.brew.sh/formula/nvm
-* MacPorts: https://ports.macports.org/port/nvm/
+1.2 Install via MacPorts
+^^^^^^^^^^^^^^^^^^^^^^^^
+Find the port here: https://ports.macports.org/port/nvm/.
 
 MacPorts needs some additional steps:
 
@@ -55,6 +57,9 @@ In this ``init-nvm.sh`` there should be:
     [ -e "$NVM_DIR/nvm.sh" ] || ln -s /opt/local/share/nvm/nvm.sh "$NVM_DIR/nvm.sh"
     [ -e "$NVM_DIR/nvm-exec" ] || ln -s /opt/local/share/nvm/nvm-exec "$NVM_DIR/nvm-exec"
 
+1.3 Install via Homebrew
+^^^^^^^^^^^^^^^^^^^^^^^^
+Follow the instructions here: https://formulae.brew.sh/formula/nvm.
 
 Troubleshooting
 ~~~~~~~~~~~~~~~

--- a/docs/source/macos/php.rst
+++ b/docs/source/macos/php.rst
@@ -22,20 +22,18 @@ Execute on the command line:
 
 .. code:: console
 
+   sudo port install php84-fpm php84-mysql php84-imagick php84-gd php84-curl php84-opcache php84-mbstring php84-xsl php84-intl php84-sqlite php84-zip php84-openssl php84-iconv php84-sockets php84-exif php84-memcached php84-redis php84-sodium
+   sudo port install php83-fpm php83-mysql php83-imagick php83-gd php83-curl php83-opcache php83-mbstring php83-xsl php83-intl php83-sqlite php83-zip php83-openssl php83-iconv php83-sockets php83-exif php83-memcached php83-redis php83-sodium
+   sudo port install php82-fpm php82-mysql php82-imagick php82-gd php82-curl php82-opcache php82-mbstring php82-xsl php82-intl php82-sqlite php82-zip php82-openssl php82-iconv php82-sockets php82-exif php82-memcached php82-redis php82-sodium
    sudo port install php81-fpm php81-mysql php81-imagick php81-gd php81-curl php81-opcache php81-mbstring php81-xsl php81-intl php81-sqlite php81-zip php81-openssl php81-iconv php81-sockets php81-exif php81-memcached php81-redis php81-sodium
    sudo port install php80-fpm php80-mysql php80-imagick php80-gd php80-curl php80-opcache php80-mbstring php80-xsl php80-intl php80-sqlite php80-zip php80-openssl php80-iconv php80-sockets php80-exif php80-memcached php80-redis php80-sodium
    sudo port install php74-fpm php74-mysql php74-imagick php74-gd php74-curl php74-opcache php74-mbstring php74-xsl php74-intl php74-sqlite php74-zip php74-openssl php74-iconv php74-sockets php74-exif php74-memcached php74-redis php74-sodium
-   sudo port install php73-fpm php73-mysql php73-imagick php73-gd php73-curl php73-opcache php73-mbstring php73-xsl php73-intl php73-sqlite php73-zip php73-openssl php73-iconv php73-sockets php73-exif php73-memcached php73-redis php73-sodium
-   sudo port install php72-fpm php72-mysql php72-imagick php72-gd php72-curl php72-opcache php72-mbstring php72-xsl php72-intl php72-sqlite php72-zip php72-openssl php72-iconv php72-sockets php72-exif php72-memcached php72-redis php72-sodium
-   sudo port install php71-fpm php71-mysql php71-imagick php71-gd php71-curl php71-opcache php71-mbstring php71-xsl php71-intl php71-sqlite php71-zip php71-openssl php71-iconv php71-sockets php71-exif php71-memcached php71-redis
-   sudo port install php70-fpm php70-mysql php70-imagick php70-gd php70-curl php70-opcache php70-mbstring php70-xsl php70-intl php70-sqlite php70-zip php70-openssl php70-iconv php70-sockets php70-exif php70-memcached php70-redis
-   sudo port install php56-fpm php56-mysql php56-imagick php56-gd php56-curl php56-opcache php56-mbstring php56-xsl php56-intl php56-sqlite php56-zip php56-openssl php56-iconv php56-sockets php56-exif php56-memcached php56-redis
 
 Select desired default PHP version:
 
 .. code:: console
 
-   sudo port select php php74
+   sudo port select php php84
 
 This PHP version will be available from the command line as ``php``.
 
@@ -64,10 +62,7 @@ Now you can install PHP 7.1, 7.0 and 5.6 with:
    brew install exolnet/deprecated/php@7.0
    brew install exolnet/deprecated/php@5.6
 
-2 Configure
------------
-
-2.1 Configure PHP-FPM pool definitions
+2 Configure PHP-FPM pool definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For each PHP version edit PHP-FPM pool definition files (documented
@@ -107,7 +102,37 @@ active and how much memory they use you can check the list of processes
 page for the specific PHP version, for example
 https://home.php73/status?full&html.
 
-2.1 Configure PHP-FPM pool definitions if installed using Homebrew
+2.1 Configure PHP-FPM pool definitions if installed using MacPorts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, create PHP-FPM pool definitions by copying the default ones:
+
+.. code:: console
+
+   sudo cp /opt/local/etc/php84/php-fpm.d/www.conf.default /opt/local/etc/php84/php-fpm.d/www.conf
+   sudo cp /opt/local/etc/php83/php-fpm.d/www.conf.default /opt/local/etc/php83/php-fpm.d/www.conf
+   sudo cp /opt/local/etc/php82/php-fpm.d/www.conf.default /opt/local/etc/php82/php-fpm.d/www.conf
+   sudo cp /opt/local/etc/php81/php-fpm.d/www.conf.default /opt/local/etc/php81/php-fpm.d/www.conf
+   sudo cp /opt/local/etc/php80/php-fpm.d/www.conf.default /opt/local/etc/php80/php-fpm.d/www.conf
+   sudo cp /opt/local/etc/php74/php-fpm.d/www.conf.default /opt/local/etc/php74/php-fpm.d/www.conf
+
+Update the created pool definition files as described above.
+
+Next, create PHP-FPM configuration files by copying the default ones:
+
+.. code:: console
+
+   sudo cp /opt/local/etc/php84/php-fpm.conf.default /opt/local/etc/php84/php-fpm.conf
+   sudo cp /opt/local/etc/php83/php-fpm.conf.default /opt/local/etc/php83/php-fpm.conf
+   sudo cp /opt/local/etc/php82/php-fpm.conf.default /opt/local/etc/php82/php-fpm.conf
+   sudo cp /opt/local/etc/php81/php-fpm.conf.default /opt/local/etc/php81/php-fpm.conf
+   sudo cp /opt/local/etc/php80/php-fpm.conf.default /opt/local/etc/php80/php-fpm.conf
+   sudo cp /opt/local/etc/php74/php-fpm.conf.default /opt/local/etc/php74/php-fpm.conf
+
+You **don’t need to change** the default configuration values.
+
+
+2.2 Configure PHP-FPM pool definitions if installed using Homebrew
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Find PHP-FPM pool definitions for your PHP versions in following files
@@ -115,48 +140,8 @@ Find PHP-FPM pool definitions for your PHP versions in following files
 .. code:: text
 
    /usr/local/etc/php/7.4/php-fpm.d/www.conf
-   /usr/local/etc/php/7.3/php-fpm.d/www.conf
-   /usr/local/etc/php/7.2/php-fpm.d/www.conf
-   /usr/local/etc/php/7.1/php-fpm.d/www.conf
-   /usr/local/etc/php/7.0/php-fpm.d/www.conf
-   /usr/local/etc/php/5.6/php-fpm.conf
 
 Update these pool definition files as described above.
-
-2.2 Configure PHP-FPM pool definitions if installed using MacPorts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-First create PHP-FPM configuration files by copying the default ones:
-
-.. code:: console
-
-   sudo cp /opt/local/etc/php81/php-fpm.conf.default /opt/local/etc/php81/php-fpm.conf
-   sudo cp /opt/local/etc/php80/php-fpm.conf.default /opt/local/etc/php80/php-fpm.conf
-   sudo cp /opt/local/etc/php74/php-fpm.conf.default /opt/local/etc/php74/php-fpm.conf
-   sudo cp /opt/local/etc/php73/php-fpm.conf.default /opt/local/etc/php73/php-fpm.conf
-   sudo cp /opt/local/etc/php72/php-fpm.conf.default /opt/local/etc/php72/php-fpm.conf
-   sudo cp /opt/local/etc/php71/php-fpm.conf.default /opt/local/etc/php71/php-fpm.conf
-   sudo cp /opt/local/etc/php70/php-fpm.conf.default /opt/local/etc/php70/php-fpm.conf
-   sudo cp /opt/local/etc/php56/php-fpm.conf.default /opt/local/etc/php56/php-fpm.conf
-
-You don’t need to change the default configuration values.
-
-Next, create PHP-FPM pool definitions by copying the default ones:
-
-.. code:: console
-
-   sudo cp /opt/local/etc/php81/php-fpm.d/www.conf.default /opt/local/etc/php81/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php80/php-fpm.d/www.conf.default /opt/local/etc/php80/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php74/php-fpm.d/www.conf.default /opt/local/etc/php74/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php73/php-fpm.d/www.conf.default /opt/local/etc/php73/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php72/php-fpm.d/www.conf.default /opt/local/etc/php72/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php71/php-fpm.d/www.conf.default /opt/local/etc/php71/php-fpm.d/www.conf
-   sudo cp /opt/local/etc/php70/php-fpm.d/www.conf.default /opt/local/etc/php70/php-fpm.d/www.conf
-
-**Note**: similar as with Homebrew, for PHP 5.6 pool definition in the
-main FPM configuration file.
-
-Update the created pool definition files as described above.
 
 3 Configure PHP
 ---------------
@@ -177,7 +162,32 @@ set the correct PHP version depending on the ini file you’re modifying.
 **Note**: Configuration files use ``;`` character as a comment, so make
 sure you remove it as needed.
 
-3.1 Configure PHP if using macOS and Homebrew
+3.1 Configure PHP if using macOS and MacPorts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First create PHP configuration files by copying the default ones:
+
+.. code:: console
+
+   sudo cp /opt/local/etc/php84/php.ini-development /opt/local/etc/php84/php.ini
+   sudo cp /opt/local/etc/php83/php.ini-development /opt/local/etc/php83/php.ini
+   sudo cp /opt/local/etc/php82/php.ini-development /opt/local/etc/php82/php.ini
+   sudo cp /opt/local/etc/php81/php.ini-development /opt/local/etc/php81/php.ini
+   sudo cp /opt/local/etc/php80/php.ini-development /opt/local/etc/php80/php.ini
+   sudo cp /opt/local/etc/php74/php.ini-development /opt/local/etc/php74/php.ini
+
+Update the created configuration files as described above and
+additionally with:
+
+.. code:: ini
+
+   pdo_mysql.default_socket=/opt/local/var/run/mysql/mysqld.sock
+   mysqli.default_socket=/opt/local/var/run/mysql/mysqld.sock
+
+This will enable using ``localhost`` as the database host from your
+application.
+
+3.2 Configure PHP if using macOS and Homebrew
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Find the configuration for your PHP versions in the following files:
@@ -193,37 +203,37 @@ Find the configuration for your PHP versions in the following files:
 
 Update these configuration files as described above.
 
-3.2 Configure PHP if using macOS and MacPorts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-First create PHP configuration files by copying the default ones:
-
-.. code:: console
-
-   sudo cp /opt/local/etc/php81/php.ini-development /opt/local/etc/php81/php.ini
-   sudo cp /opt/local/etc/php80/php.ini-development /opt/local/etc/php80/php.ini
-   sudo cp /opt/local/etc/php74/php.ini-development /opt/local/etc/php74/php.ini
-   sudo cp /opt/local/etc/php73/php.ini-development /opt/local/etc/php73/php.ini
-   sudo cp /opt/local/etc/php72/php.ini-development /opt/local/etc/php72/php.ini
-   sudo cp /opt/local/etc/php71/php.ini-development /opt/local/etc/php71/php.ini
-   sudo cp /opt/local/etc/php70/php.ini-development /opt/local/etc/php70/php.ini
-   sudo cp /opt/local/etc/php56/php.ini-development /opt/local/etc/php56/php.ini
-
-Update the created configuration files as described above and
-additionally with:
-
-.. code:: ini
-
-   pdo_mysql.default_socket=/opt/local/var/run/mysql/mysqld.sock
-   mysqli.default_socket=/opt/local/var/run/mysql/mysqld.sock
-
-This will enable using ``localhost`` as the database host from your
-application.
 
 4 Symlink PHP binaries
 ----------------------
 
-4.1 Symlink PHP binaries on macOS with Homebrew
+4.1 Symlink PHP binaries on macOS with MacPorts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Note**: while MacPorts already provides binaries for each PHP version,
+we want to add new symlinks to make it in line with Linux, which is used
+on production servers. The only difference between them is in the dot
+placed between major and minor version numbers.
+
+Symlink each PHP binary to an easily accessible alias (you might need to create the ``/usr/local/bin`` folder first):
+
+.. code:: console
+
+   sudo ln -s /opt/local/bin/php84 /usr/local/bin/php8.4
+   sudo ln -s /opt/local/bin/php83 /usr/local/bin/php8.3
+   sudo ln -s /opt/local/bin/php82 /usr/local/bin/php8.2
+   sudo ln -s /opt/local/bin/php81 /usr/local/bin/php8.1
+   sudo ln -s /opt/local/bin/php80 /usr/local/bin/php8.0
+   sudo ln -s /opt/local/bin/php74 /usr/local/bin/php7.4
+
+For these binaries to be accessible through tab completion, you'll need to reset the completion cache:
+
+.. code:: console
+
+   rm -f ~/.zcompdump*
+   exec zsh
+
+4.2 Symlink PHP binaries on macOS with Homebrew
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Symlink each PHP binary to an easily accessible alias:
@@ -241,27 +251,6 @@ Make sure you use correct paths to the PHP binary. This path will change
 when upgrading a PHP version, so you will need to maintain your symlinks
 through upgrades.
 
-4.2 Symlink PHP binaries on macOS with MacPorts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**Note**: while MacPorts already provides binaries for each PHP version,
-we want to add new symlinks to make it in line with Linux, which is used
-on production servers. The only difference between them is in the dot
-placed between major and minor version numbers.
-
-Symlink each PHP binary to an easily accessible alias:
-
-.. code:: console
-
-   sudo ln -s /opt/local/bin/php81 /usr/local/bin/php8.1
-   sudo ln -s /opt/local/bin/php80 /usr/local/bin/php8.0
-   sudo ln -s /opt/local/bin/php74 /usr/local/bin/php7.4
-   sudo ln -s /opt/local/bin/php73 /usr/local/bin/php7.3
-   sudo ln -s /opt/local/bin/php72 /usr/local/bin/php7.2
-   sudo ln -s /opt/local/bin/php71 /usr/local/bin/php7.1
-   sudo ln -s /opt/local/bin/php70 /usr/local/bin/php7.0
-   sudo ln -s /opt/local/bin/php56 /usr/local/bin/php5.6
-
 4.4 Test
 ~~~~~~~~
 
@@ -269,19 +258,47 @@ Test you can access PHP binary aliases by executing:
 
 .. code:: console
 
+   php8.4 -v
+   php8.3 -v
+   php8.2 -v
+   php8.1 -v
+   php8.0 -v
    php7.4 -v
-   php7.3 -v
-   php7.2 -v
-   php7.1 -v
-   php7.0 -v
-   php5.6 -v
 
 5 Start PHP-FPM services
 ------------------------
 
 You can now start PHP services.
 
-5.1 Start PHP-FPM services if installed using Homebrew
+5.1 Start PHP-FPM services if installed using MacPorts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: console
+
+   sudo port load php84-fpm
+   sudo port load php83-fpm
+   sudo port load php82-fpm
+   sudo port load php81-fpm
+   sudo port load php80-fpm
+   sudo port load php74-fpm
+
+This will also ensure that PHP-FPM server starts automatically after a
+reboot.
+
+Remember to restart them after changing PHP configuration in the future
+with:
+
+.. code:: console
+
+   sudo port reload phpxx-fpm
+
+To stop the server and prevent it from running after a reboot, execute:
+
+.. code:: console
+
+   sudo port unload phpxx-fpm
+
+5.2 Start PHP-FPM services if installed using Homebrew
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: console
@@ -309,35 +326,6 @@ To stop the server and prevent it from running after a reboot, execute:
 
    sudo brew services stop phpxx-fpm
 
-5.2 Start PHP-FPM services if installed using MacPorts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code:: console
-
-   sudo port load php81-fpm
-   sudo port load php80-fpm
-   sudo port load php74-fpm
-   sudo port load php73-fpm
-   sudo port load php72-fpm
-   sudo port load php71-fpm
-   sudo port load php70-fpm
-   sudo port load php56-fpm
-
-This will also ensure that PHP-FPM server starts automatically after a
-reboot.
-
-Remember to restart them after changing PHP configuration in the future
-with:
-
-.. code:: console
-
-   sudo port reload phpxx-fpm
-
-To stop the server and prevent it from running after a reboot, execute:
-
-.. code:: console
-
-   sudo port unload phpxx-fpm
 
 6 Install PHP extensions
 ------------------------

--- a/docs/source/macos/rabbitmq.rst
+++ b/docs/source/macos/rabbitmq.rst
@@ -51,16 +51,7 @@ resources, it’s preferred to start RabbitMQ manually when needed.
 3.1 Start manually (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-3.1.1 If using MacOS with Homebrew
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Execute on the command line:
-
-.. code:: console
-
-   rabbitmq-server
-
-3.1.2 If using MacOS with MacPorts
+3.1.1 If using MacOS with MacPorts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Execute on the command line:
@@ -72,6 +63,14 @@ Execute on the command line:
 The server will run in the foreground, and you can stop it when needed
 with ``Control-C``.
 
+3.1.2 If using MacOS with Homebrew
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Execute on the command line:
+
+.. code:: console
+
+   rabbitmq-server
 
 3.2 Start automatically
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/macos/solr.rst
+++ b/docs/source/macos/solr.rst
@@ -1,5 +1,5 @@
-Set up Apache Solr
-==================
+Set up Apache Solr (optional)
+=============================
 
 Here you will install Apache Solr. Open
 https://downloads.apache.org/lucene/solr in your browser and find the

--- a/docs/source/macos/ssl.rst
+++ b/docs/source/macos/ssl.rst
@@ -171,16 +171,16 @@ Create ``~/ssl/server.conf`` file with the following content:
 5 Create RCA certificate and private key
 ----------------------------------------
 
-**Note**: 3650 days means the certificate will be valid for 10 years.
-
-When prompted, use the password you chose previously.
-
 Execute on the command line:
 
 .. code:: console
 
    cd ~/ssl
    sudo openssl req -x509 -new -days 3650 -keyout root.key -out root.crt -config root.conf
+
+When prompted, use the password you chose previously.
+
+**Note**: 3650 days means the certificate will be valid for 10 years.
 
 6 Create server certificate signing request
 -------------------------------------------
@@ -195,16 +195,17 @@ Execute on the command line:
 7 Create server certificate and its private key
 -----------------------------------------------
 
-**Note**: 825 days is maximum allowed end-entity certificate validity.
-
-When prompted, use the password you chose previously.
-
 Execute on the command line:
 
 .. code:: console
 
    cd ~/ssl
    sudo openssl x509 -sha256 -req -days 825 -in server.csr -CA root.crt -CAkey root.key -CAcreateserial -out server.crt -extfile server.conf -extensions x509_ext
+
+When prompted, use the password you chose previously.
+
+**Note**: 825 days is maximum allowed end-entity certificate validity.
+
 
 8 Create certificate chain file
 -------------------------------
@@ -214,7 +215,7 @@ Execute on the command line:
 .. code:: console
 
    cd ~/ssl
-   cat server.crt server.key root.crt > chain.pem
+   sudo cat server.crt server.key root.crt > chain.pem
 
 9 Register RCA certificate with the OS
 --------------------------------------

--- a/docs/source/macos/varnish.rst
+++ b/docs/source/macos/varnish.rst
@@ -1,5 +1,5 @@
-Set up Varnish reverse HTTP proxy
-=================================
+Set up Varnish reverse HTTP proxy (optional)
+============================================
 
 1 Install Varnish
 -----------------

--- a/docs/source/macos/xdebug.rst
+++ b/docs/source/macos/xdebug.rst
@@ -1,5 +1,5 @@
-Set up XDebug
-=============
+Set up XDebug (optional)
+========================
 
 XDebug is an extension for PHP that will help us with code debugging.
 We’ll use it combined with PHP Storm, which will provide us the step


### PR DESCRIPTION
While setting up my new mac, I kept track of what was outdated and made notes along the way. These changes bring the LDS in line with the current projects and make it a bit more readable.

Putting the formatting fixes aside, here is the gist:
- update the needed PHP versions (drop <7.4, add up to 8.4)
- remove composer1 as it is not used on ongoing projects
- remove the "Update network connections" step in dnsmasq (not needed on newer macos versions)
- mark xdebug, solr and varnish as optional
- keep the order consistent through whole instructions (Macports first, then Homebrew) 